### PR TITLE
Adjust README file and removes non-working Parallel RPC endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The following parachains are currently supported with direct RPC endpoints:
 
 ```bash
 git clone [repository-url]
-cd web-migration
+cd polkadot-web-migration
 ```
 
 2. Install dependencies:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ The following parachains are currently supported with direct RPC endpoints:
 - **Kusama** (KSM)
 - **Kusama Asset Hub** (KSM)
 - **Nodle** (NODL)
-- **Parallel** (PARA)
 - **Pendulum** (PEN)
 - **Phala** (PHA)
 - **Picasso** (PICA)

--- a/config/appsConfig.json
+++ b/config/appsConfig.json
@@ -278,7 +278,6 @@
     "cla": 166,
     "bip44Path": "m/44'/354'/0'/0'/0'",
     "ss58Prefix": 172,
-    "rpcEndpoint": "wss://parallel.gatotech.network",
     "token": {
       "symbol": "PARA",
       "decimals": 12

--- a/config/mockData.ts
+++ b/config/mockData.ts
@@ -18,4 +18,4 @@ export const errorApps = process.env.NEXT_PUBLIC_ERROR_SYNC_APPS?.split(',') as 
 
 export const MINIMUM_AMOUNT = process.env.NEXT_PUBLIC_NATIVE_TRANSFER_AMOUNT
   ? parseInt(process.env.NEXT_PUBLIC_NATIVE_TRANSFER_AMOUNT)
-  : 100
+  : undefined

--- a/state/client/ledger.tsx
+++ b/state/client/ledger.tsx
@@ -77,7 +77,7 @@ export const ledgerClient = {
       const nftsToTransfer = [...(account.balance?.uniques || []), ...(account.balance?.nfts || [])]
 
       // Get native amount if available
-      const nativeAmount = process.env.NEXT_PUBLIC_NODE_ENV === 'development' ? MINIMUM_AMOUNT : account.balance?.native
+      const nativeAmount = process.env.NEXT_PUBLIC_NODE_ENV === 'development' && MINIMUM_AMOUNT ? MINIMUM_AMOUNT : account.balance?.native
 
       // Prepare transaction with all assets
       const preparedTx = await prepareTransaction(api, senderAddress, receiverAddress, nftsToTransfer, appConfig, nativeAmount)


### PR DESCRIPTION
Removes the Parallel RPC endpoint from the configuration and documentation.

The endpoint is no longer functional, so it is removed to avoid confusion.