### PR TITLE
Allow to withdraw, improve unstaking form and columns in sync table

### DIFF
--- a/components/hooks/useTokenLogo.ts
+++ b/components/hooks/useTokenLogo.ts
@@ -1,0 +1,14 @@
+import { uiState$ } from 'state/ui'
+
+/**
+ * useTokenLogo
+ *
+ * Returns the icon object for a given token.
+ *
+ * @param token - The token object containing a logoId
+ * @returns The icon object or undefined if not found
+ */
+export function useTokenLogo(tokenLogoId: string | undefined): string | undefined {
+  if (!tokenLogoId) return undefined
+  return uiState$.icons.get()[tokenLogoId]
+}

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@/lib/utils/styles'
+
 export function UsersIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
@@ -69,11 +71,11 @@ export function SearchIcon(props: React.SVGProps<SVGSVGElement>) {
   )
 }
 
-export function Spinner() {
+export function Spinner({ className }: { className?: string }) {
   return (
     <div className="flex items-center justify-center h-full">
       <svg
-        className="animate-spin h-5 w-5 text-gray-700"
+        className={cn('animate-spin h-5 w-5 text-gray-700', className)}
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/components/sections/migrate/accounts-table.tsx
+++ b/components/sections/migrate/accounts-table.tsx
@@ -1,220 +1,24 @@
 import type { Observable } from '@legendapp/state'
 import { observer } from '@legendapp/state/react'
 import { motion } from 'framer-motion'
-import { AlertCircle, Info, MoreVertical, TriangleAlert } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 import type { Collections } from 'state/ledger'
 import type { Address, AddressBalance } from 'state/types/ledger'
 
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
-import { SimpleTooltip } from '@/components/ui/tooltip'
 import type { AppId, Token } from '@/config/apps'
-import { formatBalance } from '@/lib/utils'
-import { canUnstake, hasNonTransferableBalance, hasStakedBalance, isNativeBalance } from '@/lib/utils/balance'
 
-import { AddressLink } from '@/components/AddressLink'
-import { Spinner } from '@/components/icons'
-import { BalanceHoverCard, LockedBalanceHoverCard } from './balance-hover-card'
-import DestinationAddressSelect from './destination-address-select'
-import UnstakeDialog from './unstake-dialog'
+import SynchronizedAccountRow from './synchronized-account-row'
 
-// Component for rendering a single account balance row
-interface AccountBalanceRowProps {
-  account: Address
-  accountIndex: number
-  balance?: AddressBalance
-  balanceIndex?: number
-  rowSpan: number
-  collections?: Collections
-  token: Token
-  polkadotAddresses: string[]
-  handleDestinationChange: (value: string, accountIndex: number, balanceIndex: number) => void
-  appId: AppId
-}
-
-const AccountBalanceRow = observer(
-  ({
-    account,
-    accountIndex,
-    balance,
-    balanceIndex,
-    rowSpan,
-    collections,
-    token,
-    polkadotAddresses,
-    handleDestinationChange,
-    appId,
-  }: AccountBalanceRowProps) => {
-    const [unstakeOpen, setUnstakeOpen] = useState(false)
-    const isNoBalance = balance === undefined
-    const isFirst = balanceIndex === 0 || isNoBalance
-    const isNative = isNativeBalance(balance)
-    const hasStaked = isNative && hasStakedBalance(balance)
-    const stakingActive = isNative ? (balance?.balance.staking?.active ?? 0) : undefined
-    const maxUnstake = stakingActive
-    const isUnstakeAvailable = isNative ? canUnstake(balance) : false
-
-    const actions = []
-    if (hasStaked) {
-      actions.push({
-        label: 'Unstake',
-        tooltip: !isUnstakeAvailable ? 'Only the controller address can unstake this balance' : undefined,
-        onClick: () => setUnstakeOpen(true),
-        disabled: !isUnstakeAvailable,
-      })
-    }
-
-    const renderStatusIcon = (account: Address) => {
-      let statusIcon: React.ReactNode | null = null
-      let tooltipContent = 'Checking status...'
-
-      if (account.isLoading) {
-        statusIcon = <Spinner />
-        tooltipContent = 'Loading...'
-      }
-
-      return statusIcon ? <SimpleTooltip tooltipText={tooltipContent}>{statusIcon}</SimpleTooltip> : null
-    }
-
-    const renderLockedBalance = (balance: AddressBalance) => {
-      if (!balance) return null
-
-      // Check if native balance has frozen funds or if transferable is less than total
-      const isNative = isNativeBalance(balance)
-      const hasNonTransferableBalanceWith = isNative && hasNonTransferableBalance(balance)
-
-      return (
-        <div className="flex flex-row items-center justify-end gap-2">
-          <LockedBalanceHoverCard balance={isNative ? balance?.balance : undefined} token={token} />
-          {hasNonTransferableBalanceWith && (
-            <SimpleTooltip
-              tooltipText={`Not all balance is transferable${actions.length > 0 ? ' - see available actions at the end of the row' : ''}`}
-            >
-              <TriangleAlert className="h-4 w-4 text-red-500" />
-            </SimpleTooltip>
-          )}
-        </div>
-      )
-    }
-
-    const renderTransferableBalance = () => {
-      const transferableBalance = isNative ? (balance?.balance.transferable ?? 0) : 0
-      const balances = balance ? [balance] : []
-
-      return (
-        <div className="flex flex-row items-center justify-end gap-2">
-          <span className="font-mono">{formatBalance(transferableBalance, token)}</span>
-          {!isNative ? <BalanceHoverCard balances={balances} collections={collections} token={token} isMigration /> : null}
-        </div>
-      )
-    }
-
-    const totalBalance = isNative ? (balance?.balance.total ?? 0) : 0
-
-    return (
-      <TableRow key={`${account.address ?? accountIndex}-${balance?.type}`}>
-        {/* Source Address */}
-        {isFirst && (
-          <TableCell className="py-2 text-sm" rowSpan={rowSpan}>
-            <AddressLink
-              value={account.address ?? ''}
-              tooltipText={`${account.address ?? ''} - ${account.path ?? ''}`}
-              className="break-all"
-            />
-          </TableCell>
-        )}
-        {/* Public Key */}
-        {isFirst && (
-          <TableCell className="py-2 text-sm" rowSpan={rowSpan}>
-            <AddressLink value={account.pubKey ?? ''} tooltipText={account.pubKey ?? ''} className="break-all" />
-          </TableCell>
-        )}
-        {/* Destination Address */}
-        <TableCell className="py-2 text-sm">
-          {balance !== undefined && balanceIndex !== undefined ? (
-            <DestinationAddressSelect
-              balance={balance}
-              index={balanceIndex}
-              polkadotAddresses={polkadotAddresses}
-              onDestinationChange={value => handleDestinationChange(value, accountIndex, balanceIndex)}
-            />
-          ) : (
-            '-'
-          )}
-        </TableCell>
-        {/* Total Balance */}
-        <TableCell className="py-2 text-sm text-right w-1/4 font-mono">
-          {balance !== undefined ? formatBalance(totalBalance, token) : '-'}
-        </TableCell>
-        {/* Transferable */}
-        <TableCell className="py-2 text-sm text-right w-1/4">{balance !== undefined ? renderTransferableBalance() : '-'}</TableCell>
-        {/* Locked */}
-        <TableCell className="py-2 text-sm text-right w-1/4">{balance !== undefined ? renderLockedBalance(balance) : '-'}</TableCell>
-        {/* Actions */}
-        <TableCell>
-          <div className="flex gap-2 justify-end items-center">
-            {account.error?.description && (
-              <SimpleTooltip tooltipText={account.error?.description ?? ''}>
-                <AlertCircle className="h-4 w-4 text-destructive cursor-help" />
-              </SimpleTooltip>
-            )}
-            {renderStatusIcon(account)}
-          </div>
-          {/* Additional Actions */}
-          {actions.length > 0 && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <MoreVertical className="h-4 w-4 text-muted-foreground cursor-pointer" />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                {actions.map(action => (
-                  <div key={action.label} className={`flex flex-row items-center justify-between gap-2 ${action.tooltip ? 'mr-2' : ''}`}>
-                    <DropdownMenuItem
-                      key={action.label}
-                      onClick={action.onClick}
-                      disabled={action.disabled}
-                      className={`flex gap-2 ${!action.tooltip ? 'w-full' : ''}`}
-                    >
-                      {action.label}
-                    </DropdownMenuItem>
-                    {action.tooltip && (
-                      <SimpleTooltip tooltipText={action.tooltip}>
-                        <Info className="h-4 w-4 cursor-help" />
-                      </SimpleTooltip>
-                    )}
-                  </div>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-        </TableCell>
-        <UnstakeDialog
-          open={unstakeOpen}
-          setOpen={setUnstakeOpen}
-          maxUnstake={maxUnstake ?? 0}
-          token={token}
-          account={account}
-          appId={appId}
-        />
-      </TableRow>
-    )
-  }
-)
-
-function AccountsTable({
-  accounts,
-  token,
-  polkadotAddresses,
-  collections,
-  appId,
-}: {
+interface AccountsTableProps {
   accounts: Observable<Address[] | undefined>
   token: Token
   polkadotAddresses: string[]
   collections?: Collections
   appId: AppId
-}) {
+}
+
+function AccountsTable({ accounts, token, polkadotAddresses, collections, appId }: AccountsTableProps) {
   const accountsList = accounts.get() ?? []
 
   const handleDestinationChange = useCallback(
@@ -235,12 +39,11 @@ function AccountsTable({
         <TableHeader>
           <TableRow>
             <TableHead className="text-left">Source Address</TableHead>
-            <TableHead className="text-left">Public Key</TableHead>
             <TableHead className="text-left">Destination Address</TableHead>
             <TableHead className="text-right">Total Balance</TableHead>
             <TableHead className="text-right">Transferable</TableHead>
             <TableHead className="text-right">Locked</TableHead>
-            <TableHead className="w-[100px]" />
+            <TableHead className="w-[100px]">Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -250,7 +53,7 @@ function AccountsTable({
 
               if (balances.length === 0 && account.error) {
                 return (
-                  <AccountBalanceRow
+                  <SynchronizedAccountRow
                     key={`${account.address ?? accountIndex}`}
                     account={account}
                     accountIndex={accountIndex}
@@ -265,7 +68,7 @@ function AccountsTable({
               }
 
               return balances.map((balance: AddressBalance, balanceIndex: number) => (
-                <AccountBalanceRow
+                <SynchronizedAccountRow
                   key={`${account.address ?? accountIndex}-${balance.type}`}
                   account={account}
                   accountIndex={accountIndex}

--- a/components/sections/migrate/balance-detail-card.tsx
+++ b/components/sections/migrate/balance-detail-card.tsx
@@ -1,6 +1,6 @@
 import { BalanceType, type Collection, type Native } from 'state/types/ledger'
-import { uiState$ } from 'state/ui'
 
+import { useTokenLogo } from '@/components/hooks/useTokenLogo'
 import TokenIcon from '@/components/TokenIcon'
 import { Badge, type BadgeVariant } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -68,7 +68,7 @@ interface NativeTokensDetailCardProps {
  * Shows the token's native status and formatted balance amount
  */
 const NativeTokensDetailCard = ({ balance, token }: NativeTokensDetailCardProps) => {
-  const icon = uiState$.icons.get()[token.logoId || '']
+  const icon = useTokenLogo(token.logoId)
   const total = Number(formatBalance(balance.total || 0, token, undefined, true))
 
   return (

--- a/components/sections/migrate/synchronized-account-row.tsx
+++ b/components/sections/migrate/synchronized-account-row.tsx
@@ -1,0 +1,228 @@
+import { observer } from '@legendapp/state/react'
+import { AlertCircle, Info, TriangleAlert } from 'lucide-react'
+import { useState } from 'react'
+import type { Collections } from 'state/ledger'
+import type { Address, AddressBalance } from 'state/types/ledger'
+
+import { TableCell, TableRow } from '@/components/ui/table'
+import { SimpleTooltip, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import type { AppId, Token } from '@/config/apps'
+import { cn, formatBalance } from '@/lib/utils'
+import { canUnstake, hasNonTransferableBalance, hasStakedBalance, isNativeBalance } from '@/lib/utils/balance'
+
+import { AddressLink } from '@/components/AddressLink'
+import { Spinner } from '@/components/icons'
+import { Button, type ButtonVariant } from '@/components/ui/button'
+import { BalanceHoverCard, LockedBalanceHoverCard } from './balance-hover-card'
+import DestinationAddressSelect from './destination-address-select'
+import UnstakeDialog from './unstake-dialog'
+import WithdrawDialog from './withdraw-dialog'
+
+// Component for rendering a single synchronized account row
+interface AccountBalanceRowProps {
+  account: Address
+  accountIndex: number
+  balance?: AddressBalance
+  balanceIndex?: number
+  rowSpan: number
+  collections?: Collections
+  token: Token
+  polkadotAddresses: string[]
+  handleDestinationChange: (value: string, accountIndex: number, balanceIndex: number) => void
+  appId: AppId
+}
+
+interface Action {
+  label: string
+  tooltip?: string
+  onClick: () => void
+  disabled: boolean
+  variant: ButtonVariant
+}
+
+const SynchronizedAccountRow = observer(
+  ({
+    account,
+    accountIndex,
+    balance,
+    balanceIndex,
+    rowSpan,
+    collections,
+    token,
+    polkadotAddresses,
+    handleDestinationChange,
+    appId,
+  }: AccountBalanceRowProps) => {
+    const [unstakeOpen, setUnstakeOpen] = useState<boolean>(false)
+    const [withdrawOpen, setWithdrawOpen] = useState<boolean>(false)
+    const isNoBalance: boolean = balance === undefined
+    const isFirst: boolean = balanceIndex === 0 || isNoBalance
+    const isNative = isNativeBalance(balance)
+    const hasStaked: boolean = isNative && hasStakedBalance(balance)
+    const stakingActive: number | undefined = isNative ? (balance?.balance.staking?.active ?? 0) : undefined
+    const maxUnstake: number = stakingActive ?? 0
+    const isUnstakeAvailable: boolean = isNative ? canUnstake(balance) : false
+    const totalBalance: number = isNative ? (balance?.balance.total ?? 0) : 0
+
+    const actions: Action[] = []
+    if (hasStaked) {
+      actions.push({
+        label: 'Unstake',
+        tooltip: !isUnstakeAvailable ? 'Only the controller address can unstake this balance' : undefined,
+        onClick: () => setUnstakeOpen(true),
+        disabled: !isUnstakeAvailable,
+        variant: 'secondary',
+      })
+    }
+    const canWithdraw: boolean = isNative ? (balance?.balance.staking?.unlocking?.some(u => u.canWithdraw) ?? false) : false
+    if (canWithdraw) {
+      actions.push({
+        label: 'Withdraw',
+        tooltip: 'Withdraw the balance',
+        onClick: () => setWithdrawOpen(true),
+        disabled: false,
+        variant: 'outline',
+      })
+    }
+
+    const renderStatusIcon = (account: Address): React.ReactNode | null => {
+      let statusIcon: React.ReactNode | null = null
+      let tooltipContent = 'Checking status...'
+
+      if (account.isLoading) {
+        statusIcon = <Spinner />
+        tooltipContent = 'Loading...'
+      }
+
+      return statusIcon ? <SimpleTooltip tooltipText={tooltipContent}>{statusIcon}</SimpleTooltip> : null
+    }
+
+    const renderLockedBalance = (balance: AddressBalance): React.ReactNode | null => {
+      if (!balance) return null
+
+      // Check if native balance has frozen funds or if transferable is less than total
+      const isNative = isNativeBalance(balance)
+      const hasNonTransferableBalanceWith: boolean = isNative && hasNonTransferableBalance(balance)
+
+      return (
+        <div className="flex flex-row items-center justify-end gap-2">
+          <LockedBalanceHoverCard balance={isNative ? balance?.balance : undefined} token={token} />
+          {hasNonTransferableBalanceWith && (
+            <SimpleTooltip
+              tooltipText={`Not all balance is transferable${actions.length > 0 ? ' - see available actions at the end of the row' : ''}`}
+            >
+              <TriangleAlert className="h-4 w-4 text-red-500" />
+            </SimpleTooltip>
+          )}
+        </div>
+      )
+    }
+
+    const renderTransferableBalance = () => {
+      const transferableBalance: number = isNative ? (balance?.balance.transferable ?? 0) : 0
+      const balances: AddressBalance[] = balance ? [balance] : []
+
+      return (
+        <div className="flex flex-row items-center justify-end gap-2">
+          <span className="font-mono">{formatBalance(transferableBalance, token)}</span>
+          {!isNative ? <BalanceHoverCard balances={balances} collections={collections} token={token} isMigration /> : null}
+        </div>
+      )
+    }
+
+    const tooltipAddres = (): React.ReactNode => (
+      <div className="flex flex-col p-2 min-w-[320px]">
+        {(
+          [
+            { label: 'Source Address', value: account.address },
+            { label: 'Derivation Path', value: account.path },
+            { label: 'Public Key', value: account.pubKey },
+          ] as { label: string; value: string }[]
+        ).map(item => (
+          <div key={item.label}>
+            <span className="text-xs text-muted-foreground">{item.label}</span>
+            <AddressLink value={item.value} disableTooltip truncate={false} className="break-all" />
+          </div>
+        ))}
+      </div>
+    )
+
+    const renderAction = (action: Action): React.ReactNode => {
+      const button = (
+        <Button key={action.label} variant={action.variant} size="sm" onClick={action.onClick} disabled={action.disabled}>
+          {action.label}
+        </Button>
+      )
+      return action.tooltip ? (
+        <SimpleTooltip tooltipText={action.tooltip} key={action.label}>
+          <div className="inline-block">{button}</div>
+        </SimpleTooltip>
+      ) : (
+        button
+      )
+    }
+
+    return (
+      <TableRow key={`${account.address ?? accountIndex}-${balance?.type}`}>
+        {/* Source Address */}
+        {isFirst && (
+          <TableCell className="py-2 text-sm" rowSpan={rowSpan}>
+            <div className="flex items-center gap-2">
+              <AddressLink value={account.address ?? ''} disableTooltip className="break-all" />
+              <TooltipProvider>
+                <Tooltip delayDuration={0}>
+                  <TooltipTrigger asChild>
+                    <Info className="h-4 w-4 text-muted-foreground cursor-help" />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" align="center" className={cn('z-[100] break-words whitespace-normal')} sideOffset={5}>
+                    {tooltipAddres()}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+          </TableCell>
+        )}
+        {/* Destination Address */}
+        <TableCell className="py-2 text-sm">
+          {balance !== undefined && balanceIndex !== undefined ? (
+            <DestinationAddressSelect
+              balance={balance}
+              index={balanceIndex}
+              polkadotAddresses={polkadotAddresses}
+              onDestinationChange={value => handleDestinationChange(value, accountIndex, balanceIndex)}
+            />
+          ) : (
+            '-'
+          )}
+        </TableCell>
+        {/* Total Balance */}
+        <TableCell className="py-2 text-sm text-right w-1/4 font-mono">
+          {balance !== undefined ? formatBalance(totalBalance, token) : '-'}
+        </TableCell>
+        {/* Transferable */}
+        <TableCell className="py-2 text-sm text-right w-1/4">{balance !== undefined ? renderTransferableBalance() : '-'}</TableCell>
+        {/* Locked */}
+        <TableCell className="py-2 text-sm text-right w-1/4">{balance !== undefined ? renderLockedBalance(balance) : '-'}</TableCell>
+        {/* Actions */}
+        <TableCell>
+          <div className="flex gap-2 justify-end items-center">
+            {account.error?.description && (
+              <SimpleTooltip tooltipText={account.error?.description ?? ''}>
+                <AlertCircle className="h-4 w-4 text-destructive cursor-help" />
+              </SimpleTooltip>
+            )}
+            {renderStatusIcon(account)}
+          </div>
+          {/* Additional Actions */}
+          {actions.length > 0 ? (
+            <div className="flex gap-2 justify-start items-center">{actions.map(action => renderAction(action))}</div>
+          ) : null}
+        </TableCell>
+        <UnstakeDialog open={unstakeOpen} setOpen={setUnstakeOpen} maxUnstake={maxUnstake} token={token} account={account} appId={appId} />
+        <WithdrawDialog open={withdrawOpen} setOpen={setWithdrawOpen} token={token} account={account} appId={appId} />
+      </TableRow>
+    )
+  }
+)
+
+export default SynchronizedAccountRow

--- a/components/sections/migrate/transaction-dialog.tsx
+++ b/components/sections/migrate/transaction-dialog.tsx
@@ -1,0 +1,94 @@
+import { AddressLink } from '@/components/AddressLink'
+import { Button } from '@/components/ui/button'
+import { getTransactionStatus } from '@/lib/utils/ui'
+import { type Transaction, TransactionStatus } from '@/state/types/ledger'
+
+/**
+ * TransactionStatusBody
+ *
+ * Displays the status of a blockchain transaction, including a status icon, a message,
+ * and optional transaction details such as transaction hash, block hash, and block number.
+ */
+function TransactionStatusBody({ status, statusMessage: txStatusMessage, hash, blockHash, blockNumber }: Transaction) {
+  if (!status) return null
+
+  // Collect transaction details only if they exist, and filter out undefined values for cleaner display
+  const details: { label: string; value: string }[] = [
+    { label: 'Transaction Hash', value: hash },
+    { label: 'Block Hash', value: blockHash },
+    { label: 'Block Number', value: blockNumber },
+  ].filter((item): item is { label: string; value: string } => Boolean(item.value))
+
+  // Common transaction details section to display hash, blockHash and blockNumber if they exist
+  const renderTransactionDetails = () => {
+    return (
+      <div className="text-xs w-full">
+        {details.map(
+          item =>
+            item.value && (
+              <div key={item.label} className="flex justify-between items-center gap-1">
+                <div className="text-xs text-muted-foreground mb-1">{item.label}</div>
+                <AddressLink value={item.value} />
+              </div>
+            )
+        )}
+      </div>
+    )
+  }
+
+  const { statusIcon, statusMessage } = getTransactionStatus(status, txStatusMessage, 'lg')
+
+  return (
+    <div className="w-full flex flex-col items-center space-y-4">
+      {statusIcon}
+      <span className="text-base font-medium max-w-[80%] text-center">
+        {status === TransactionStatus.IS_LOADING ? 'Please sign the transaction in your Ledger device' : statusMessage}
+      </span>
+      {details.length > 0 && renderTransactionDetails()}
+    </div>
+  )
+}
+
+interface TransactionDialogFooterProps {
+  isSignDisabled: boolean
+  isTxFinished: boolean
+  isTxFailed: boolean
+  isSynchronizing: boolean
+  clearTx: () => void
+  synchronizeAccount: () => void
+  closeDialog: () => void
+  signTransfer: () => void
+}
+
+function TransactionDialogFooter({
+  isTxFinished,
+  isTxFailed,
+  isSynchronizing,
+  clearTx,
+  synchronizeAccount,
+  closeDialog,
+  signTransfer,
+  isSignDisabled,
+}: TransactionDialogFooterProps) {
+  return (
+    <>
+      <Button variant="outline" onClick={closeDialog}>
+        {isTxFinished ? 'Close' : 'Cancel'}
+      </Button>
+      {!isTxFinished ? (
+        <Button className="bg-[#7916F3] hover:bg-[#6B46C1] text-white" onClick={signTransfer} disabled={isSignDisabled}>
+          Sign Transfer
+        </Button>
+      ) : (
+        <Button
+          className="bg-[#7916F3] hover:bg-[#6B46C1] text-white"
+          onClick={isTxFailed ? clearTx : synchronizeAccount}
+          disabled={isSynchronizing}
+        >
+          {isSynchronizing ? 'Synchronizing...' : isTxFailed ? 'Try again' : 'Update Synchronization'}
+        </Button>
+      )}
+    </>
+  )
+}
+export { TransactionDialogFooter, TransactionStatusBody }

--- a/components/sections/migrate/withdraw-dialog.tsx
+++ b/components/sections/migrate/withdraw-dialog.tsx
@@ -1,0 +1,151 @@
+import type { Address, TransactionStatus } from 'state/types/ledger'
+
+import { AddressLink } from '@/components/AddressLink'
+import { useTokenLogo } from '@/components/hooks/useTokenLogo'
+import { useTransactionStatus } from '@/components/hooks/useTransactionStatus'
+import { Spinner } from '@/components/icons'
+import TokenIcon from '@/components/TokenIcon'
+import { Dialog, DialogBody, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { type AppId, type Token, getChainName } from '@/config/apps'
+import { formatBalance } from '@/lib/utils/format'
+import { ledgerState$ } from '@/state/ledger'
+import { useEffect, useMemo } from 'react'
+import { TransactionDialogFooter, TransactionStatusBody } from './transaction-dialog'
+
+interface WithdrawDialogProps {
+  appId: AppId
+  open: boolean
+  setOpen: (open: boolean) => void
+  token: Token
+  account: Address
+}
+
+interface WithdrawFormProps {
+  token: Token
+  account: Address
+  appId: AppId
+  estimatedFee?: string
+  estimatedFeeLoading: boolean
+}
+
+function WithdrawForm({ token, account, appId, estimatedFee, estimatedFeeLoading }: WithdrawFormProps) {
+  const icon = useTokenLogo(token.logoId)
+  const appName = getChainName(appId)
+
+  return (
+    <div className="space-y-4">
+      {/* Sending account */}
+      <div className="text-sm">
+        <div className="text-xs text-muted-foreground mb-1">Source Address</div>
+        <AddressLink value={account.address} />
+      </div>
+      {/* Network */}
+      <div>
+        <div className="text-xs text-muted-foreground mb-1">Network</div>
+        <div className="flex items-center gap-2">
+          <TokenIcon icon={icon} symbol={token.symbol} size="md" />
+          <span className="font-semibold text-base">{appName}</span>
+        </div>
+      </div>
+      {/* Estimated Fee */}
+      <div className="flex flex-col items-start justify-start">
+        <div className="text-xs text-muted-foreground mb-1">Estimated Fee</div>
+        {estimatedFeeLoading ? (
+          <Spinner className="w-4 h-4" />
+        ) : (
+          <span className={`text-sm ${estimatedFee ? ' font-mono' : ''}`}>{estimatedFee ?? 'Could not be calculated at this time'}</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default function WithdrawDialog({ open, setOpen, token, account, appId }: WithdrawDialogProps) {
+  // Wrap ledgerState$.withdrawBalance to match the generic hook's expected signature
+  const withdrawTxFn = async (
+    updateTxStatus: (
+      status: TransactionStatus,
+      message?: string,
+      txDetails?: { txHash?: string; blockHash?: string; blockNumber?: string }
+    ) => void,
+    appId: AppId,
+    address: string,
+    path: string
+  ) => {
+    await ledgerState$.withdrawBalance(appId, address, path, updateTxStatus)
+  }
+
+  const {
+    runTransaction,
+    txStatus,
+    clearTx,
+    isTxFinished,
+    isTxFailed,
+    updateSynchronization,
+    isSynchronizing,
+    getEstimatedFee,
+    estimatedFee,
+    estimatedFeeLoading,
+  } = useTransactionStatus(withdrawTxFn, ledgerState$.getWithdrawFee)
+
+  // Calculate fee on mount
+  useEffect(() => {
+    if (open) {
+      getEstimatedFee(appId, account.address)
+    }
+  }, [open, getEstimatedFee, appId, account.address])
+
+  const formattedFee = useMemo(() => (estimatedFee ? formatBalance(Number(estimatedFee), token) : undefined), [estimatedFee, token])
+
+  const signWithdrawTx = async () => {
+    await runTransaction(appId, account.address, account.path)
+  }
+
+  const synchronizeAccount = async () => {
+    await updateSynchronization(ledgerState$.synchronizeAccount, appId)
+    closeDialog()
+  }
+
+  const closeDialog = () => {
+    clearTx()
+    setOpen(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={closeDialog}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Withdraw your unbonded balance</DialogTitle>
+          <DialogDescription>
+            This process may require a small transaction fee. Please review the details below before proceeding.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogBody>
+          {txStatus ? (
+            <TransactionStatusBody {...txStatus} />
+          ) : (
+            <WithdrawForm
+              token={token}
+              account={account}
+              appId={appId}
+              estimatedFee={formattedFee}
+              estimatedFeeLoading={estimatedFeeLoading}
+            />
+          )}
+        </DialogBody>
+        <DialogFooter>
+          <TransactionDialogFooter
+            isTxFinished={isTxFinished}
+            isTxFailed={isTxFailed}
+            isSynchronizing={isSynchronizing}
+            clearTx={clearTx}
+            synchronizeAccount={synchronizeAccount}
+            closeDialog={closeDialog}
+            signTransfer={signWithdrawTx}
+            isSignDisabled={Boolean(txStatus)}
+          />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,8 +1,11 @@
-import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
 
 import { cn } from '@/lib/utils'
+
+export type ButtonVariant = 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link' | 'gray' | 'purple'
+export type ButtonSize = 'default' | 'sm' | 'lg' | 'icon' | 'wide'
 
 const buttonVariants = cva(
   'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
@@ -37,9 +40,10 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   asChild?: boolean
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, variant, size, asChild = false, ...props }, ref) => {
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, variant, size, asChild = false, disabled, ...props }, ref) => {
   const Comp = asChild ? Slot : 'button'
-  return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+  // pointer-events-none is used so the button can be wrapped by a tooltip and still be triggered when disabled
+  return <Comp className={cn(buttonVariants({ variant, size, className }), disabled && 'opacity-50 pointer-events-none')} ref={ref} {...props} />
 })
 Button.displayName = 'Button'
 

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -2,19 +2,30 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  error?: boolean
+  helperText?: string
+}
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, error, helperText, ...props }, ref) => {
   return (
-    <input
-      type={type}
-      className={cn(
-        'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-        className
+    <div>
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          error
+            ? 'border-2 border-red-500 focus-visible:ring-red-500'
+            : 'border-input',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+      {helperText && (
+        <div className={cn('mt-1 text-xs', error ? 'text-red-500' : 'text-muted-foreground')}>{helperText}</div>
       )}
-      ref={ref}
-      {...props}
-    />
+    </div>
   )
 })
 Input.displayName = 'Input'

--- a/config/errors.ts
+++ b/config/errors.ts
@@ -24,6 +24,7 @@ export enum InternalErrors {
   INSUFFICIENT_BALANCE = 'insufficient_balance',
   INSUFFICIENT_BALANCE_TO_COVER_FEE = 'insufficient_balance_to_cover_fee',
   UNSTAKE_ERROR = 'unstake_error',
+  WITHDRAW_ERROR = 'withdraw_error',
 }
 
 export enum LedgerErrors {
@@ -155,6 +156,11 @@ export const errorDetails: ErrorDetailsMap = {
   unstake_error: {
     title: 'Unstake Error',
     description: 'Failed to unstake balance.',
+    content: 'Please try again later or contact support if the issue persists.',
+  },
+  withdraw_error: {
+    title: 'Withdraw Error',
+    description: 'Failed to withdraw balance.',
     content: 'Please try again later or contact support if the issue persists.',
   },
 }

--- a/lib/__tests__/account.test.ts
+++ b/lib/__tests__/account.test.ts
@@ -9,6 +9,7 @@ import {
   getEnrichedNftMetadata,
   getNativeBalance,
   ipfsToHttpUrl,
+  isReadyToWithdraw,
   processCollectionMetadata,
   processNftItem,
 } from '../account'
@@ -507,5 +508,24 @@ describe('eraToHumanTime', () => {
     expect(eraToHumanTime(0, 0)).toBe('0 hours')
     expect(eraToHumanTime(1, 0)).toBe('6 hours')
     expect(eraToHumanTime(4, 0)).toBe('1 days and 0 hours')
+  })
+})
+
+describe('isReadyToWithdraw', () => {
+  it('should return true when chunkEra is less than currentEra', () => {
+    expect(isReadyToWithdraw(5, 10)).toBe(true)
+  })
+
+  it('should return true when chunkEra is equal to currentEra', () => {
+    expect(isReadyToWithdraw(10, 10)).toBe(true)
+  })
+
+  it('should return false when chunkEra is greater than currentEra', () => {
+    expect(isReadyToWithdraw(15, 10)).toBe(false)
+  })
+
+  it('should handle negative eras', () => {
+    expect(isReadyToWithdraw(-1, 0)).toBe(true)
+    expect(isReadyToWithdraw(0, -1)).toBe(false)
   })
 })

--- a/lib/account.ts
+++ b/lib/account.ts
@@ -3,7 +3,7 @@ import { ApiPromise, WsProvider } from '@polkadot/api'
 import type { SubmittableExtrinsic } from '@polkadot/api/types'
 import type { GenericExtrinsicPayload } from '@polkadot/types'
 import type { Option, u32 } from '@polkadot/types-codec'
-import type { AccountId32, Hash, OpaqueMetadata, StakingLedger } from '@polkadot/types/interfaces'
+import type { AccountId32, Hash, OpaqueMetadata, RuntimeDispatchInfo, StakingLedger } from '@polkadot/types/interfaces'
 import type { ExtrinsicPayloadValue, ISubmittableResult } from '@polkadot/types/types/extrinsic'
 import { hexToU8a } from '@polkadot/util'
 import type { AppConfig } from 'config/apps'
@@ -318,10 +318,26 @@ export async function prepareTransaction(
   return prepareTransactionPayload(api, senderAddress, appConfig, transfer)
 }
 
-export async function prepareUnstakeTransaction(api: ApiPromise, amount: number) {
+export async function prepareUnstakeTransaction(api: ApiPromise, amount: number): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>> {
+export async function prepareUnstakeTransaction(
+  api: ApiPromise,
+  amount: number
+): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>> {
   const unstakeTx: SubmittableExtrinsic<'promise', ISubmittableResult> = api.tx.staking.unbond(amount)
 
   return unstakeTx
+}
+
+export async function prepareWithdrawTransaction(api: ApiPromise): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>> {
+  const numSlashingSpans = 0
+  const withdrawTx = api.tx.staking.withdrawUnbonded(numSlashingSpans) as SubmittableExtrinsic<'promise', ISubmittableResult>
+
+  return withdrawTx
+}
+
+export async function getTxFee(tx: SubmittableExtrinsic<'promise', ISubmittableResult>, senderAddress: string): Promise<string> {
+  const paymentInfo: RuntimeDispatchInfo = await tx.paymentInfo(senderAddress)
+  return paymentInfo.partialFee.toString()
 }
 
 // Create Signed Extrinsic
@@ -947,6 +963,16 @@ export function eraToHumanTime(era: number, currentEra: number): string {
 }
 
 /**
+ * Checks if a staking unlock chunk is ready to withdraw (era is less than or equal to current era)
+ * @param chunkEra The era of the unlock chunk
+ * @param currentEra The current era
+ * @returns True if ready to withdraw, false otherwise
+ */
+export function isReadyToWithdraw(chunkEra: number, currentEra: number): boolean {
+  return chunkEra <= currentEra
+}
+
+/**
  * Gets the staking information for an address
  * @param address The address to check
  * @param api The API instance
@@ -982,6 +1008,7 @@ export async function getStakingInfo(address: string, api: ApiPromise): Promise<
       value: chunk.value.toNumber(),
       era: Number(chunk.era.toString()),
       timeRemaining: eraToHumanTime(Number(chunk.era.toString()), currentEra),
+      canWithdraw: isReadyToWithdraw(Number(chunk.era.toString()), currentEra),
     }))
     return stakingInfo
   }

--- a/lib/account.ts
+++ b/lib/account.ts
@@ -318,7 +318,6 @@ export async function prepareTransaction(
   return prepareTransactionPayload(api, senderAddress, appConfig, transfer)
 }
 
-export async function prepareUnstakeTransaction(api: ApiPromise, amount: number): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>> {
 export async function prepareUnstakeTransaction(
   api: ApiPromise,
   amount: number

--- a/lib/utils/ui.tsx
+++ b/lib/utils/ui.tsx
@@ -3,6 +3,14 @@ import { AlertCircle, CheckCircle, Clock, XCircle } from 'lucide-react'
 
 import { Spinner } from '@/components/icons'
 
+/**
+ * Returns a status icon and message corresponding to the given transaction status.
+ *
+ * @param status - The current transaction status (optional).
+ * @param txStatusMessage - An optional custom status message to display.
+ * @param size - The size of the status icon ('sm', 'md', or 'lg'). Defaults to 'sm'.
+ * @returns An object containing the statusIcon (ReactNode) and an optional statusMessage (string).
+ */
 export const getTransactionStatus = (
   status?: TransactionStatus,
   txStatusMessage?: string,
@@ -57,6 +65,26 @@ export const getTransactionStatus = (
   return { statusIcon, statusMessage }
 }
 
-export const isValidNumberInput = (value: string): boolean => {
-  return /^\d*\.?\d*$/.test(value)
+/**
+ * Validates a numeric input value against required, numeric, positive, and maximum constraints.
+ *
+ * @param value - The input value as a string to validate.
+ * @param max - The maximum allowed value (inclusive).
+ * @returns An object with a boolean `valid` flag and a `helperText` message for user feedback.
+ */
+export const validateNumberInput = (value: string, max: number): { valid: boolean; helperText: string } => {
+  if (value === '') {
+    return { valid: false, helperText: 'Amount is required.' }
+  }
+  const numValue = Number(value)
+  if (Number.isNaN(numValue)) {
+    return { valid: false, helperText: 'Amount must be a number.' }
+  }
+  if (numValue <= 0) {
+    return { valid: false, helperText: 'Amount must be greater than zero.' }
+  }
+  if (numValue > max) {
+    return { valid: false, helperText: `Amount cannot exceed your staked balance (${max}).` }
+  }
+  return { valid: true, helperText: '' }
 }

--- a/state/ledger.ts
+++ b/state/ledger.ts
@@ -869,4 +869,50 @@ export const ledgerState$ = observable({
       updateTxStatus(TransactionStatus.ERROR, errorDetail)
     }
   },
+
+  async getUnstakeFee(appId: AppId, address: string, amount: number): Promise<string | undefined> {
+    const appConfig = appsConfigs.get(appId)
+    if (!appConfig) {
+      console.error(`App with id ${appId} not found.`)
+      return
+    }
+
+    try {
+      console.log('getUnstakeFee ledger state 1', appId, address, amount)
+      const estimatedFee = await ledgerClient.getUnstakeFee(appId, address, amount)
+      console.log('getUnstakeFee ledger state 2', estimatedFee)
+      return estimatedFee
+    } catch (error) {
+      return undefined
+    }
+  },
+
+  async withdrawBalance(appId: AppId, address: string, path: string, updateTxStatus: UpdateTransactionStatus) {
+    const appConfig = appsConfigs.get(appId)
+    if (!appConfig) {
+      console.error(`App with id ${appId} not found.`)
+      return
+    }
+
+    try {
+      await ledgerClient.withdrawBalance(appId, address, path, updateTxStatus)
+    } catch (error) {
+      const errorDetail = (error as LedgerClientError).message || errorDetails.withdraw_error.description
+      updateTxStatus(TransactionStatus.ERROR, errorDetail)
+    }
+  },
+
+  async getWithdrawFee(appId: AppId, address: string): Promise<string | undefined> {
+    const appConfig = appsConfigs.get(appId)
+    if (!appConfig) {
+      console.error(`App with id ${appId} not found.`)
+      return
+    }
+
+    try {
+      return await ledgerClient.getWithdrawFee(appId, address)
+    } catch (error) {
+      return undefined
+    }
+  },
 })

--- a/state/types/ledger.ts
+++ b/state/types/ledger.ts
@@ -154,11 +154,12 @@ export interface Staking {
     value: number
     era: number
     timeRemaining: string
+    canWithdraw: boolean
   }[]
   claimedRewards?: number[]
   stash?: string
   controller?: string
-  canUnstake?: boolean
+  canUnstake: boolean
 }
 
 /**


### PR DESCRIPTION
What's done:
* If the unstaked assets are ready to withdraw, a green message appears in the popup, and a button to withdraw appears in Actions column.
* When clicking in Withdraw, the popup to do the transaction appears, displaying the transaction estimated fee.
* Add validation in unstaking form to check the amount (it's not zero, it's not more than the balance, ...). If the amount is correct, the estimated fee appears.
* Public key column is removed and a popup with public key, derivation path and complete source address is added.
