### PR TITLE
Move logic to useMigration and delete duplicated filters.

### DIFF
--- a/components/hooks/__tests__/useMigration.test.ts
+++ b/components/hooks/__tests__/useMigration.test.ts
@@ -43,11 +43,15 @@ vi.mock('@legendapp/state', () => ({
 
 vi.mock('@/lib/utils', () => ({
   addDestinationAddressesFromAccounts: vi.fn(() => ({})),
-  filterSelectedAccountsForMigration: vi.fn(() => []),
+  filterValidSelectedAccountsForMigration: vi.fn(() => []),
   filterValidSyncedAppsWithBalances: vi.fn(() => []),
 }))
 
-import { addDestinationAddressesFromAccounts, filterSelectedAccountsForMigration, filterValidSyncedAppsWithBalances } from '@/lib/utils'
+import {
+  addDestinationAddressesFromAccounts,
+  filterValidSelectedAccountsForMigration,
+  filterValidSyncedAppsWithBalances,
+} from '@/lib/utils'
 import { ledgerState$ } from '@/state/ledger'
 import { use$ } from '@legendapp/state/react'
 import { useMigration } from '../useMigration'
@@ -61,7 +65,7 @@ describe('useMigration hook', () => {
     vi.mocked(ledgerState$.apps.migrationResult.get).mockReturnValue({ success: 0, total: 0 })
     vi.mocked(ledgerState$.apps.currentMigratedItem.get).mockReturnValue(undefined)
     vi.mocked(addDestinationAddressesFromAccounts).mockReturnValue({})
-    vi.mocked(filterSelectedAccountsForMigration).mockReturnValue([])
+    vi.mocked(filterValidSelectedAccountsForMigration).mockReturnValue([])
     vi.mocked(filterValidSyncedAppsWithBalances).mockReturnValue([])
   })
 
@@ -69,7 +73,6 @@ describe('useMigration hook', () => {
     it('should return correct initial state when no apps', () => {
       const { result } = renderHook(() => useMigration())
 
-      expect(result.current.filteredAppsWithoutErrors).toEqual([])
       expect(result.current.appsForMigration).toEqual([])
       expect(result.current.destinationAddressesByApp).toEqual({})
       expect(result.current.migratingItem).toBeDefined()
@@ -115,11 +118,10 @@ describe('useMigration hook', () => {
     it('should handle apps with accounts', () => {
       vi.mocked(ledgerState$.apps.apps.get).mockReturnValue(mockApps)
       vi.mocked(filterValidSyncedAppsWithBalances).mockReturnValue(mockApps)
-      vi.mocked(filterSelectedAccountsForMigration).mockReturnValue(mockApps)
+      vi.mocked(filterValidSelectedAccountsForMigration).mockReturnValue(mockApps)
 
       const { result } = renderHook(() => useMigration())
 
-      expect(result.current.filteredAppsWithoutErrors).toEqual(mockApps)
       expect(result.current.appsForMigration).toEqual(mockApps)
     })
 
@@ -252,7 +254,6 @@ describe('useMigration hook', () => {
 
       const { result } = renderHook(() => useMigration())
 
-      expect(result.current.filteredAppsWithoutErrors).toEqual([])
       expect(result.current.appsForMigration).toEqual([])
     })
 
@@ -278,7 +279,7 @@ describe('useMigration hook', () => {
       const { result } = renderHook(() => useMigration())
 
       // Should handle gracefully without throwing
-      expect(result.current.filteredAppsWithoutErrors).toBeDefined()
+      expect(result.current.appsForMigration).toBeDefined()
     })
   })
 

--- a/components/sections/migrate/migrate-tab-content.tsx
+++ b/components/sections/migrate/migrate-tab-content.tsx
@@ -6,7 +6,6 @@ import { useEffect, useRef, useState } from 'react'
 
 import { useMigration } from '@/components/hooks/useMigration'
 import { Button } from '@/components/ui/button'
-import { hasBalance } from '@/lib/utils'
 
 import { AddressVerificationDialog } from './dialogs/address-verification-dialog'
 import { MigrationProgressDialog } from './dialogs/migration-progress-dialog'
@@ -75,28 +74,6 @@ export function MigrateTabContent({ onBack }: MigrateTabContentProps) {
   }
 
   const hasAddressesToVerify = appsForMigration.length > 0
-  // Filter accounts and multisigAccounts that have a balance and destination address (and signatory address if multisig)
-  const validApps = appsForMigration
-    .map(app => {
-      // Filter regular accounts
-      const filteredAccounts = (app.accounts || []).filter(account =>
-        (account.balances || []).some(balance => hasBalance([balance], true) && balance.transaction?.destinationAddress)
-      )
-
-      // Filter multisigAccounts (requires destinationAddress and signatoryAddress)
-      const filteredMultisigAccounts = (app.multisigAccounts || []).filter(account =>
-        (account.balances || []).some(
-          balance => hasBalance([balance], true) && balance.transaction?.destinationAddress && balance.transaction?.signatoryAddress
-        )
-      )
-
-      return {
-        ...app,
-        accounts: filteredAccounts,
-        multisigAccounts: filteredMultisigAccounts,
-      }
-    })
-    .filter(app => app.accounts.length > 0 || app.multisigAccounts?.length > 0)
 
   return (
     <div>
@@ -111,10 +88,12 @@ export function MigrateTabContent({ onBack }: MigrateTabContentProps) {
         )}
       </div>
 
-      {validApps.length > 0 ? (
+      {appsForMigration.length > 0 ? (
         <>
-          {validApps.some(app => app.accounts?.length > 0) && <MigratedAccountsTable apps={validApps} />}
-          {validApps.some(app => app.multisigAccounts?.length > 0) && <MigratedAccountsTable apps={validApps} multisigAddresses />}
+          {appsForMigration.some(app => app.accounts && app.accounts.length > 0) && <MigratedAccountsTable apps={appsForMigration} />}
+          {appsForMigration.some(app => app.multisigAccounts && app.multisigAccounts.length > 0) && (
+            <MigratedAccountsTable apps={appsForMigration} multisigAddresses />
+          )}
         </>
       ) : (
         <div className="border border-gray-200 rounded-lg p-8 text-center">

--- a/components/sections/migrate/migrated-accounts-rows.tsx
+++ b/components/sections/migrate/migrated-accounts-rows.tsx
@@ -99,16 +99,16 @@ const MigratedAccountRows = ({ app, multisigAddresses }: AccountRowsProps) => {
         <TableCell className="p-0!">
           <div className="flex flex-col">
             {balances.map((balance, balanceIndex) => (
-              <>
+              <div key={balance.type}>
                 {balanceIndex !== 0 && <hr className="border-gray-200 my-0" />}
-                <div key={balance.type} className="py-4 px-8">
+                <div className="py-4 px-8">
                   <ExplorerLink
                     value={balance.transaction?.destinationAddress || ''}
                     appId={app.id as AppId}
                     explorerLinkType={ExplorerItemType.Address}
                   />
                 </div>
-              </>
+              </div>
             ))}
           </div>
         </TableCell>

--- a/lib/utils/ledger.ts
+++ b/lib/utils/ledger.ts
@@ -76,19 +76,35 @@ export const filterValidSyncedAppsWithBalances = (apps: App[]): App[] => {
 
 /**
  * Filters apps to only include those that have accounts that can be migrated.
- * This function filters for accounts that are selected and have not yet been migrated.
+ * This function filters for accounts that are selected and have a balance and destination address.
  *
  * @param apps - The apps to filter.
  * @returns Apps with accounts that can be migrated.
  */
-export const filterSelectedAccountsForMigration = (apps: App[]): App[] => {
-  return apps
+export const filterValidSelectedAccountsForMigration = (apps: App[]): App[] => {
+  const filteredApps = apps
     .map(app => ({
       ...app,
-      accounts: app.accounts?.filter(account => account.selected) || [],
-      multisigAccounts: app.multisigAccounts?.filter(account => account.selected) || [],
+      accounts:
+        app.accounts?.filter(
+          account =>
+            account.selected &&
+            (!account.error || account.error?.source === 'migration') &&
+            account.balances &&
+            account.balances.some(balance => hasBalance([balance], true) && balance.transaction?.destinationAddress)
+        ) || [],
+      multisigAccounts:
+        app.multisigAccounts?.filter(
+          account =>
+            account.selected &&
+            (!account.error || account.error?.source === 'migration') &&
+            account.balances &&
+            account.balances.some(balance => hasBalance([balance], true) && balance.transaction?.destinationAddress)
+        ) || [],
     }))
     .filter(app => app.accounts.length > 0 || app.multisigAccounts?.length > 0)
+
+  return filteredApps
 }
 
 /**


### PR DESCRIPTION
- Replace filterSelectedAccountsForMigration with filterValidSelectedAccountsForMigration to ensure only selected accounts with balances and destination addresses are included.
- Remove unused filteredAppsWithoutErrors computed value from useMigration hook.
- Update tests to reflect changes in account filtering logic and ensure correct initial state handling.
- Simplify MigrateTabContent component by directly using appsForMigration for rendering logic.


<!-- ClickUpRef: 8699nd04b -->
:link: [zboto Link](https://app.clickup.com/t/8699nd04b)