### PR TITLE
Add proxy and identity info to multisig

### DIFF
--- a/state/ledger.ts
+++ b/state/ledger.ts
@@ -584,10 +584,22 @@ export const ledgerState$ = observable({
             processCollections(multisigCollections)
           }
 
+          // Registration Info
+          const registration = await getIdentityInfo(multisigAddress.address, api)
+
+          // Proxy Info
+          const proxy = await getProxyInfo(multisigAddress.address, api)
+
+          // Index information
+          const indexInfo = await getIndexInfo(multisigAddress.address, api)
+
           multisigAddress.balances = multisigBalances.map(balance => ({
             ...balance,
             transaction: { ...balance.transaction, signatoryAddress: multisigAddress.members[0].address },
           }))
+          multisigAddress.registration = registration
+          multisigAddress.proxy = proxy
+          multisigAddress.index = indexInfo
           multisigAddress.status = AddressStatus.SYNCHRONIZED
           multisigAddress.error = multisigError
             ? {


### PR DESCRIPTION
<!-- ClickUpRef: 8699pp3mc -->
:link: [zboto Link](https://app.clickup.com/t/8699pp3mc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multisig addresses now display additional identity, proxy, and index information during account synchronization, providing more detailed account data to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->