### PR TITLE
update edgeware rpc endpoint

### DIFF
--- a/config/appsConfig.json
+++ b/config/appsConfig.json
@@ -100,7 +100,7 @@
     "name": "Edgeware",
     "bip44Path": "m/44'/523'/0'/0'/0'",
     "ss58Prefix": 7,
-    "rpcEndpoint": "wss://edgeware-rpc1.jelliedowl.net",
+    "rpcEndpoint": "wss://edgeware-rpc3.jelliedowl.net",
     "token": {
       "symbol": "EDG",
       "decimals": 18


### PR DESCRIPTION
The [wss://edgeware-rpc1.jelliedowl.net](wss://edgeware-rpc1.jelliedowl.net) rpc endpoint is down. I don't know since when, but [wss://edgeware-rpc3.jelliedowl.net](wss://edgeware-rpc3.jelliedowl.net) is  the only live WSS endpoint now listed on https://chainlist.org/chain/2021.
If these endpoints happen to be sporadic in availability, might make sense to define (the others as) fallback endpoints in the config.

<!-- ClickUpRef: 869a6rzbf -->
:link: [zboto Link](https://app.clickup.com/t/869a6rzbf)