### PR TITLE
Fix: Call migrateSelected() in handleMigrate to actually migrate accounts

### DIFF
--- a/components/sections/migrate/migrate-tab-content.tsx
+++ b/components/sections/migrate/migrate-tab-content.tsx
@@ -32,6 +32,7 @@ export function MigrateTabContent({ onBack }: MigrateTabContentProps) {
     migratingItem,
     getCollectionsByAppId,
     destinationAddressesByApp,
+    migrateSelected,
   } = useMigration()
   const userDismissedDialog = useRef(false)
 
@@ -47,6 +48,7 @@ export function MigrateTabContent({ onBack }: MigrateTabContentProps) {
 
   const handleMigrate = async () => {
     setMigrationStatus('loading')
+    await migrateSelected()
     setShowSuccessDialog(true)
     setMigrationStatus('finished')
   }

--- a/state/stores/index.ts
+++ b/state/stores/index.ts
@@ -8,11 +8,11 @@
 
 // Address cache store for Ledger public keys (Legend State observable)
 export {
+  type AddressCacheAdapter,
+  addressCache,
   addressCache$,
   addressCacheActions,
-  addressCache,
   useAddressCache,
-  type AddressCacheAdapter,
 } from './addressCache'
 
 // Future observable stores can be added here


### PR DESCRIPTION
Accounts weren't being migrated when clicking the "Migrate Accounts" button. The migration flow would complete and show the success dialog, but no accounts were actually migrated.

<!-- ClickUpRef: 869aq08f3 -->
:link: [zboto Link](https://app.clickup.com/t/869aq08f3)